### PR TITLE
Create proper nixos module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "django-nixos": {
       "locked": {
-        "lastModified": 1646072542,
-        "narHash": "sha256-KwEj/E+Bz+g5/e+GV0+j9S2HN7yNXZHBTSt7aSRpRtQ=",
+        "lastModified": 1646809200,
+        "narHash": "sha256-tQCMndhyra7cVV1izPvXmJ3pY6SMHIJ6ZhuENL+Tt98=",
         "owner": "pnmadelaine",
         "repo": "django-nixos",
-        "rev": "62c17fad1b71e737a0f2ccc2a1293da0881bd52a",
+        "rev": "0c30e449e404b8975c7f0c1a20d9ee227a244449",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "django-nixos": {
       "locked": {
-        "lastModified": 1642402800,
-        "narHash": "sha256-BrsOBGymjgl8tS8nXETGqyN4p9oAFTDQFnVWifZrCq0=",
+        "lastModified": 1646072542,
+        "narHash": "sha256-KwEj/E+Bz+g5/e+GV0+j9S2HN7yNXZHBTSt7aSRpRtQ=",
         "owner": "pnmadelaine",
         "repo": "django-nixos",
-        "rev": "31d154470c32ecdc87961b052e5641b852de3a6c",
+        "rev": "62c17fad1b71e737a0f2ccc2a1293da0881bd52a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,12 +20,6 @@
         source ${./dev_secrets.sh}
       '';
     };
-    mkNixosModule = { fqdn, keys-file }: django-nixos.lib.mkNixosModule {
-      name = "imacs";
-      inherit pkgs;
-      inherit keys-file fqdn;
-      src = ./.;
-      settings = "imacs.settings.nix";
-    };
+    nixosModules.imacs = { imports = [ django-nixos.nixosModules.django ./module.nix ]; };
   };
 }

--- a/imacs/settings/nix-unsafe.py
+++ b/imacs/settings/nix-unsafe.py
@@ -1,0 +1,17 @@
+from os import environ
+from .app_settings import *
+
+SECRET_KEY=environ.get('SECRET_KEY')
+STATIC_ROOT=environ.get('STATIC_ROOT')
+ALLOWED_HOSTS = list(environ.get('ALLOWED_HOSTS', default='').split(','))
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': environ.get('DB_NAME'),
+        'HOST': '',
+    }
+}
+DEBUG = False
+SECURE_SSL_REDIRECT = False
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,57 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.imacs;
+  inherit (lib) types;
+in {
+  options = {
+    services.imacs = {
+      enable = lib.mkEnableOption "Intelligent Multi-Agent Chores Scheduler";
+      unsafeSettings = lib.mkOption {
+        description = ''
+          Disable security settings, for testing only.
+          You may have to clear your browser HSTS cache for it to take effect.
+        '';
+        type = types.bool;
+        default = false;
+      };
+      hostName = lib.mkOption {
+        description = "The hostname IMACS is served on";
+        type = types.nonEmptyStr;
+        default = "localhost";
+      };
+      keysFile = lib.mkOption {
+        description = "Path to the secret keys file";
+        type = types.either types.nonEmptyStr types.path;
+      };
+      setupNginx = lib.mkOption {
+        description = "Whether to setup nginx";
+        type = types.bool;
+        default = true;
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable
+    (lib.mkMerge [
+      {
+        services.django.enable = true;
+        services.django.servers.imacs = {
+          root = ./.;
+          settings = if cfg.unsafeSettings
+                     then "imacs.settings.nix-unsafe"
+                     else "imacs.settings.nix";
+          port = 8001;
+          inherit (cfg) keysFile setupNginx hostName;
+        };
+
+        warnings = if cfg.unsafeSettings
+                   then [ "IMACS is configured with unsafe settings" ]
+                   else [ ];
+      }
+      (lib.mkIf (cfg.enable && cfg.setupNginx) { services.nginx.enable = true; })
+      (lib.mkIf (cfg.enable && cfg.setupNginx && !cfg.unsafeSettings) {
+        services.nginx.virtualHosts."${cfg.hostName}".forceSSL = true;
+      })
+    ]);
+}

--- a/module.nix
+++ b/module.nix
@@ -44,6 +44,7 @@ in {
             if cfg.unsafeSettings
             then "imacs.settings.nix-unsafe"
             else "imacs.settings.nix";
+          security.noNetwork = true;
         };
       }
       (lib.mkIf (cfg.enable && cfg.setupNginx) { services.nginx.enable = true; })


### PR DESCRIPTION
This PR can not be merged until https://github.com/pnmadelaine/django-nixos/pull/1 is merged and the `flake.lock` is updated.

Improves the interface by creating a proper NixOS module to setup imacs.